### PR TITLE
Pre-release testing

### DIFF
--- a/example_scripts/connect_to_star_hub.py
+++ b/example_scripts/connect_to_star_hub.py
@@ -32,4 +32,5 @@ if __name__ == "__main__":
     print(f"{hub} contains {len(hub.channels)} channels in total:")
     for channel in hub.channels:
         print(channel)
+    hub.reset()
     hub.disconnect()

--- a/example_scripts/continuous_multi_fifo_mode.py
+++ b/example_scripts/continuous_multi_fifo_mode.py
@@ -1,3 +1,5 @@
+"""Continuous Multi-FIFO mode (SPC_REC_FIFO_MULTI) example. The function defined here is used by the tests module as an
+integration test."""
 from time import monotonic
 from typing import List
 
@@ -13,7 +15,8 @@ from spectrumdevice.settings import (
 )
 
 
-def continuous_multi_fifo_example(mock_mode: bool, acquisition_duration_in_seconds: float) -> List[List[ndarray]]:
+def continuous_multi_fifo_example(mock_mode: bool, acquisition_duration_in_seconds: float,
+                                  trigger_source: TriggerSource) -> List[List[ndarray]]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
@@ -27,7 +30,7 @@ def continuous_multi_fifo_example(mock_mode: bool, acquisition_duration_in_secon
 
     # Trigger settings
     trigger_settings = TriggerSettings(
-        trigger_sources=[TriggerSource.SPC_TMASK_EXT0],
+        trigger_sources=[trigger_source],
         external_trigger_mode=ExternalTriggerMode.SPC_TM_POS,
         external_trigger_level_in_mv=1000,
     )
@@ -67,7 +70,8 @@ if __name__ == "__main__":
 
     from matplotlib.pyplot import plot, show, figure, title
 
-    measurements = continuous_multi_fifo_example(mock_mode=True, acquisition_duration_in_seconds=4.0)
+    measurements = continuous_multi_fifo_example(mock_mode=True, acquisition_duration_in_seconds=4.0,
+                                                 trigger_source=TriggerSource.SPC_TMASK_EXT0)
 
     # Plot waveforms
     for n, measurement in enumerate(measurements):

--- a/example_scripts/continuous_multi_fifo_mode.py
+++ b/example_scripts/continuous_multi_fifo_mode.py
@@ -1,7 +1,7 @@
 """Continuous Multi-FIFO mode (SPC_REC_FIFO_MULTI) example. The function defined here is used by the tests module as an
 integration test."""
 from time import monotonic
-from typing import List
+from typing import List, Optional
 
 from numpy import ndarray
 
@@ -16,12 +16,12 @@ from spectrumdevice.settings import (
 
 
 def continuous_multi_fifo_example(mock_mode: bool, acquisition_duration_in_seconds: float,
-                                  trigger_source: TriggerSource) -> List[List[ndarray]]:
+                                  trigger_source: TriggerSource, ip_address: Optional[str] = None)\
+        -> List[List[ndarray]]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
-        DEVICE_IP_ADDRESS = "169.254.142.75"
-        card = SpectrumCard(device_number=0, ip_address=DEVICE_IP_ADDRESS)
+        card = SpectrumCard(device_number=0, ip_address=ip_address)
     else:
         # Set up a mock device
         card = MockSpectrumCard(

--- a/example_scripts/continuous_multi_fifo_mode.py
+++ b/example_scripts/continuous_multi_fifo_mode.py
@@ -42,9 +42,9 @@ def continuous_multi_fifo_example(mock_mode: bool, acquisition_duration_in_secon
         acquisition_length_in_samples=400,
         pre_trigger_length_in_samples=0,
         timeout_in_ms=1000,
-        enabled_channels=[0, 1, 2, 3],
-        vertical_ranges_in_mv=[200, 200, 200, 200],
-        vertical_offsets_in_percent=[0, 0, 0, 0],
+        enabled_channels=[0],
+        vertical_ranges_in_mv=[200],
+        vertical_offsets_in_percent=[0],
     )
 
     # Apply settings

--- a/example_scripts/continuous_multi_fifo_mode.py
+++ b/example_scripts/continuous_multi_fifo_mode.py
@@ -15,9 +15,13 @@ from spectrumdevice.settings import (
 )
 
 
-def continuous_multi_fifo_example(mock_mode: bool, acquisition_duration_in_seconds: float,
-                                  trigger_source: TriggerSource, device_number: int, ip_address: Optional[str] = None)\
-        -> List[List[ndarray]]:
+def continuous_multi_fifo_example(
+    mock_mode: bool,
+    acquisition_duration_in_seconds: float,
+    trigger_source: TriggerSource,
+    device_number: int,
+    ip_address: Optional[str] = None,
+) -> List[List[ndarray]]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
@@ -72,9 +76,12 @@ if __name__ == "__main__":
 
     from matplotlib.pyplot import plot, show, figure, title
 
-    measurements = continuous_multi_fifo_example(mock_mode=True, acquisition_duration_in_seconds=4.0,
-                                                 trigger_source=TriggerSource.SPC_TMASK_EXT0,
-                                                 device_number=0)
+    measurements = continuous_multi_fifo_example(
+        mock_mode=True,
+        acquisition_duration_in_seconds=4.0,
+        trigger_source=TriggerSource.SPC_TMASK_EXT0,
+        device_number=0,
+    )
 
     # Plot waveforms
     for n, measurement in enumerate(measurements):

--- a/example_scripts/finite_multi_fifo_mode.py
+++ b/example_scripts/finite_multi_fifo_mode.py
@@ -1,6 +1,6 @@
 """Finite Multi-FIFO mode (SPC_REC_FIFO_MULTI) example. The function defined here is used by the tests module as an
 integration test."""
-from typing import List
+from typing import List, Optional
 
 from numpy import ndarray
 
@@ -15,12 +15,11 @@ from spectrumdevice.settings import (
 
 
 def finite_multi_fifo_example(mock_mode: bool, num_measurements: int,
-                              trigger_source: TriggerSource) -> List[List[ndarray]]:
+                              trigger_source: TriggerSource, ip_address: Optional[str] = None) -> List[List[ndarray]]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
-        DEVICE_IP_ADDRESS = "169.254.142.75"
-        card = SpectrumCard(device_number=0, ip_address=DEVICE_IP_ADDRESS)
+        card = SpectrumCard(device_number=0, ip_address=ip_address)
     else:
         # Set up a mock device
         card = MockSpectrumCard(

--- a/example_scripts/finite_multi_fifo_mode.py
+++ b/example_scripts/finite_multi_fifo_mode.py
@@ -15,15 +15,16 @@ from spectrumdevice.settings import (
 
 
 def finite_multi_fifo_example(mock_mode: bool, num_measurements: int,
-                              trigger_source: TriggerSource, ip_address: Optional[str] = None) -> List[List[ndarray]]:
+                              trigger_source: TriggerSource, device_number: int,
+                              ip_address: Optional[str] = None) -> List[List[ndarray]]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
-        card = SpectrumCard(device_number=0, ip_address=ip_address)
+        card = SpectrumCard(device_number=device_number, ip_address=ip_address)
     else:
         # Set up a mock device
         card = MockSpectrumCard(
-            device_number=0, mock_source_frame_rate_hz=10.0, num_modules=2, num_channels_per_module=4
+            device_number=device_number, mock_source_frame_rate_hz=10.0, num_modules=2, num_channels_per_module=4
         )
 
     # Trigger settings
@@ -50,7 +51,10 @@ def finite_multi_fifo_example(mock_mode: bool, num_measurements: int,
     card.configure_acquisition(acquisition_settings)
 
     # Execute acquisition
-    return card.execute_finite_multi_fifo_acquisition(num_measurements)
+    waveform_list = card.execute_finite_multi_fifo_acquisition(num_measurements)
+    card.reset()
+    card.disconnect()
+    return waveform_list
 
 
 if __name__ == "__main__":
@@ -58,7 +62,7 @@ if __name__ == "__main__":
     from matplotlib.pyplot import plot, show, figure, title
 
     measurements = finite_multi_fifo_example(mock_mode=True, num_measurements=2,
-                                             trigger_source=TriggerSource.SPC_TMASK_EXT0)
+                                             trigger_source=TriggerSource.SPC_TMASK_EXT0, device_number=0)
 
     # Plot waveforms
     for n, measurement in enumerate(measurements):

--- a/example_scripts/finite_multi_fifo_mode.py
+++ b/example_scripts/finite_multi_fifo_mode.py
@@ -1,3 +1,5 @@
+"""Finite Multi-FIFO mode (SPC_REC_FIFO_MULTI) example. The function defined here is used by the tests module as an
+integration test."""
 from typing import List
 
 from numpy import ndarray
@@ -12,7 +14,8 @@ from spectrumdevice.settings import (
 )
 
 
-def finite_multi_fifo_example(mock_mode: bool, num_measurements: int) -> List[List[ndarray]]:
+def finite_multi_fifo_example(mock_mode: bool, num_measurements: int,
+                              trigger_source: TriggerSource) -> List[List[ndarray]]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
@@ -26,7 +29,7 @@ def finite_multi_fifo_example(mock_mode: bool, num_measurements: int) -> List[Li
 
     # Trigger settings
     trigger_settings = TriggerSettings(
-        trigger_sources=[TriggerSource.SPC_TMASK_EXT0],
+        trigger_sources=[trigger_source],
         external_trigger_mode=ExternalTriggerMode.SPC_TM_POS,
         external_trigger_level_in_mv=1000,
     )
@@ -55,7 +58,8 @@ if __name__ == "__main__":
 
     from matplotlib.pyplot import plot, show, figure, title
 
-    measurements = finite_multi_fifo_example(mock_mode=True, num_measurements=2)
+    measurements = finite_multi_fifo_example(mock_mode=True, num_measurements=2,
+                                             trigger_source=TriggerSource.SPC_TMASK_EXT0)
 
     # Plot waveforms
     for n, measurement in enumerate(measurements):

--- a/example_scripts/finite_multi_fifo_mode.py
+++ b/example_scripts/finite_multi_fifo_mode.py
@@ -14,9 +14,13 @@ from spectrumdevice.settings import (
 )
 
 
-def finite_multi_fifo_example(mock_mode: bool, num_measurements: int,
-                              trigger_source: TriggerSource, device_number: int,
-                              ip_address: Optional[str] = None) -> List[List[ndarray]]:
+def finite_multi_fifo_example(
+    mock_mode: bool,
+    num_measurements: int,
+    trigger_source: TriggerSource,
+    device_number: int,
+    ip_address: Optional[str] = None,
+) -> List[List[ndarray]]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
@@ -61,8 +65,9 @@ if __name__ == "__main__":
 
     from matplotlib.pyplot import plot, show, figure, title
 
-    measurements = finite_multi_fifo_example(mock_mode=True, num_measurements=2,
-                                             trigger_source=TriggerSource.SPC_TMASK_EXT0, device_number=0)
+    measurements = finite_multi_fifo_example(
+        mock_mode=True, num_measurements=2, trigger_source=TriggerSource.SPC_TMASK_EXT0, device_number=0
+    )
 
     # Plot waveforms
     for n, measurement in enumerate(measurements):

--- a/example_scripts/finite_multi_fifo_mode.py
+++ b/example_scripts/finite_multi_fifo_mode.py
@@ -41,9 +41,9 @@ def finite_multi_fifo_example(mock_mode: bool, num_measurements: int,
         acquisition_length_in_samples=400,
         pre_trigger_length_in_samples=0,
         timeout_in_ms=1000,
-        enabled_channels=[0, 1, 2, 3],
-        vertical_ranges_in_mv=[200, 200, 200, 200],
-        vertical_offsets_in_percent=[0, 0, 0, 0],
+        enabled_channels=[0],
+        vertical_ranges_in_mv=[200],
+        vertical_offsets_in_percent=[0],
     )
 
     # Apply settings

--- a/example_scripts/standard_single_mode.py
+++ b/example_scripts/standard_single_mode.py
@@ -41,9 +41,9 @@ def standard_single_mode_example(mock_mode: bool, trigger_source: TriggerSource,
         acquisition_length_in_samples=400,
         pre_trigger_length_in_samples=0,
         timeout_in_ms=1000,
-        enabled_channels=[0, 1, 2, 3],
-        vertical_ranges_in_mv=[200, 200, 200, 200],
-        vertical_offsets_in_percent=[0, 0, 0, 0],
+        enabled_channels=[0],
+        vertical_ranges_in_mv=[200],
+        vertical_offsets_in_percent=[0],
     )
 
     # Apply settings

--- a/example_scripts/standard_single_mode.py
+++ b/example_scripts/standard_single_mode.py
@@ -15,16 +15,16 @@ from spectrumdevice.settings import (
 )
 
 
-def standard_single_mode_example(mock_mode: bool, trigger_source: TriggerSource, ip_address: Optional[str] = None)\
-        -> List[ndarray]:
+def standard_single_mode_example(mock_mode: bool, trigger_source: TriggerSource, device_number: int,
+                                 ip_address: Optional[str] = None) -> List[ndarray]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
-        card = SpectrumCard(device_number=0, ip_address=ip_address)
+        card = SpectrumCard(device_number=device_number, ip_address=ip_address)
     else:
         # Set up a mock device
         card = MockSpectrumCard(
-            device_number=0, mock_source_frame_rate_hz=10.0, num_modules=2, num_channels_per_module=4
+            device_number=device_number, mock_source_frame_rate_hz=10.0, num_modules=2, num_channels_per_module=4
         )
 
     # Trigger settings
@@ -51,14 +51,19 @@ def standard_single_mode_example(mock_mode: bool, trigger_source: TriggerSource,
     card.configure_acquisition(acquisition_settings)
 
     # Execute acquisition
-    return card.execute_standard_single_acquisition()
+    waveform_list = card.execute_standard_single_acquisition()
+    card.reset()
+    card.disconnect()
+    return waveform_list
 
 
 if __name__ == "__main__":
 
     from matplotlib.pyplot import plot, show
 
-    waveforms = standard_single_mode_example(mock_mode=True, trigger_source=TriggerSource.SPC_TMASK_EXT0)
+    waveforms = standard_single_mode_example(mock_mode=True, trigger_source=TriggerSource.SPC_TMASK_EXT0,
+                                             device_number=0)
+
     # Plot waveforms
     for waveform in waveforms:
         plot(waveform)

--- a/example_scripts/standard_single_mode.py
+++ b/example_scripts/standard_single_mode.py
@@ -15,8 +15,9 @@ from spectrumdevice.settings import (
 )
 
 
-def standard_single_mode_example(mock_mode: bool, trigger_source: TriggerSource, device_number: int,
-                                 ip_address: Optional[str] = None) -> List[ndarray]:
+def standard_single_mode_example(
+    mock_mode: bool, trigger_source: TriggerSource, device_number: int, ip_address: Optional[str] = None
+) -> List[ndarray]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
@@ -61,8 +62,9 @@ if __name__ == "__main__":
 
     from matplotlib.pyplot import plot, show
 
-    waveforms = standard_single_mode_example(mock_mode=True, trigger_source=TriggerSource.SPC_TMASK_EXT0,
-                                             device_number=0)
+    waveforms = standard_single_mode_example(
+        mock_mode=True, trigger_source=TriggerSource.SPC_TMASK_EXT0, device_number=0
+    )
 
     # Plot waveforms
     for waveform in waveforms:

--- a/example_scripts/standard_single_mode.py
+++ b/example_scripts/standard_single_mode.py
@@ -1,3 +1,6 @@
+"""Standard Single Mode (SPC_REC_STD_SINGLE) example. The function defined here is used by the tests module as an
+integration test."""
+
 from typing import List
 
 from numpy import ndarray
@@ -12,7 +15,7 @@ from spectrumdevice.settings import (
 )
 
 
-def standard_single_mode_example(mock_mode: bool) -> List[ndarray]:
+def standard_single_mode_example(mock_mode: bool, trigger_source: TriggerSource) -> List[ndarray]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
@@ -26,7 +29,7 @@ def standard_single_mode_example(mock_mode: bool) -> List[ndarray]:
 
     # Trigger settings
     trigger_settings = TriggerSettings(
-        trigger_sources=[TriggerSource.SPC_TMASK_EXT0],
+        trigger_sources=[trigger_source],
         external_trigger_mode=ExternalTriggerMode.SPC_TM_POS,
         external_trigger_level_in_mv=1000,
     )
@@ -55,7 +58,7 @@ if __name__ == "__main__":
 
     from matplotlib.pyplot import plot, show
 
-    waveforms = standard_single_mode_example(mock_mode=True)
+    waveforms = standard_single_mode_example(mock_mode=True, trigger_source=TriggerSource.SPC_TMASK_EXT0)
     # Plot waveforms
     for waveform in waveforms:
         plot(waveform)

--- a/example_scripts/standard_single_mode.py
+++ b/example_scripts/standard_single_mode.py
@@ -1,7 +1,7 @@
 """Standard Single Mode (SPC_REC_STD_SINGLE) example. The function defined here is used by the tests module as an
 integration test."""
 
-from typing import List
+from typing import List, Optional
 
 from numpy import ndarray
 
@@ -15,12 +15,12 @@ from spectrumdevice.settings import (
 )
 
 
-def standard_single_mode_example(mock_mode: bool, trigger_source: TriggerSource) -> List[ndarray]:
+def standard_single_mode_example(mock_mode: bool, trigger_source: TriggerSource, ip_address: Optional[str] = None)\
+        -> List[ndarray]:
 
     if not mock_mode:
         # Connect to a networked device. To connect to a local (PCIe) device, do not provide an ip_address.
-        DEVICE_IP_ADDRESS = "169.254.142.75"
-        card = SpectrumCard(device_number=0, ip_address=DEVICE_IP_ADDRESS)
+        card = SpectrumCard(device_number=0, ip_address=ip_address)
     else:
         # Set up a mock device
         card = MockSpectrumCard(

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ ignore_errors = True
 ignore_errors = True
 
 [flake8]
-exclude = .bzr,.hg,.git,__pycache__,.tox,setup.py,.eggs,spectrum_gmbh,scratch,htmlcov,.pytest_cache,.mypy_cache,.github
+exclude = .bzr,.hg,.git,__pycache__,.tox,setup.py,.eggs,spectrum_gmbh,scratch,htmlcov,.pytest_cache,.mypy_cache,.github,_version.py
 max-line-length = 120
 application_import_names = spectrumdevice, tests
 import-order-style = pycharm

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,7 @@ ignore=E127,E126,W504,W503,F541,E501
 markers =
     integration: marks tests as an integration test (deselect with '-m "not integration"').
     only_without_driver: marks test to only be run on systems without Spectrum drivers installed (e.g. during CI).
+    star_hub: marks test which can be run on star hub hardware devices
 
 [versioneer]
 VCS = git

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,7 +102,8 @@ ignore=E127,E126,W504,W503,F541,E501
 
 [tool:pytest]
 markers =
-    integration: marks tests as an integration test (deselect with '-m "not integration"')
+    integration: marks tests as an integration test (deselect with '-m "not integration"').
+    only_without_driver: marks test to only be run on systems without Spectrum drivers installed (e.g. during CI).
 
 [versioneer]
 VCS = git

--- a/spectrumdevice/devices/spectrum_card.py
+++ b/spectrumdevice/devices/spectrum_card.py
@@ -551,16 +551,17 @@ class SpectrumCard(SpectrumDevice):
         )
 
     @property
-    def feature_list(self) -> Tuple[List[CardFeature], List[AdvancedCardFeature]]:
+    def feature_list(self) -> List[Tuple[List[CardFeature], List[AdvancedCardFeature]]]:
         """Get a list of the features of the card. See CardFeature, AdvancedCardFeature and the Spectrum
         documentation for more information.
 
         Returns:
-            features (Tuple[List[CardFeature], List[AdvancedCardFeature]]): A list of features and advanced features.
+            features (List[Tuple[List[CardFeature], List[AdvancedCardFeature]]]): A tuple of two lists - of features and
+                advanced features respectively - wrapped in a list.
         """
         normal_features = decode_card_features(self.read_spectrum_device_register(SPC_PCIFEATURES))
         advanced_features = decode_advanced_card_features(self.read_spectrum_device_register(SPC_PCIEXTFEATURES))
-        return normal_features, advanced_features
+        return [(normal_features, advanced_features)]
 
     @property
     def sample_rate_in_hz(self) -> int:

--- a/spectrumdevice/devices/spectrum_device.py
+++ b/spectrumdevice/devices/spectrum_device.py
@@ -26,6 +26,7 @@ from spectrumdevice.devices.spectrum_interface import (
     SpectrumDeviceInterface,
 )
 from spectrumdevice.settings import SpectrumRegisterLength, AcquisitionMode, TriggerSettings, AcquisitionSettings
+from spectrumdevice.settings.triggering import EXTERNAL_TRIGGER_SOURCES
 from spectrumdevice.spectrum_wrapper import (
     get_spectrum_i32_api_param,
     get_spectrum_i64_api_param,
@@ -101,12 +102,13 @@ class SpectrumDevice(SpectrumDeviceInterface, ABC):
         Args:
             settings (TriggerSettings): A TriggerSettings dataclass containing the setting values to apply."""
         self.set_trigger_sources(settings.trigger_sources)
-        if settings.external_trigger_mode is not None:
-            self.set_external_trigger_mode(settings.external_trigger_mode)
-        if settings.external_trigger_level_in_mv is not None:
-            self.set_external_trigger_level_in_mv(settings.external_trigger_level_in_mv)
-        if settings.external_trigger_pulse_width_in_samples is not None:
-            self.set_external_trigger_pulse_width_in_samples(settings.external_trigger_pulse_width_in_samples)
+        if len(set(self.trigger_sources) & set(EXTERNAL_TRIGGER_SOURCES)) > 0:
+            if settings.external_trigger_mode is not None:
+                self.set_external_trigger_mode(settings.external_trigger_mode)
+            if settings.external_trigger_level_in_mv is not None:
+                self.set_external_trigger_level_in_mv(settings.external_trigger_level_in_mv)
+            if settings.external_trigger_pulse_width_in_samples is not None:
+                self.set_external_trigger_pulse_width_in_samples(settings.external_trigger_pulse_width_in_samples)
 
     def execute_standard_single_acquisition(self) -> List[ndarray]:
         """Carry out an single measurement in standard single mode and return the acquired waveforms.

--- a/spectrumdevice/devices/spectrum_interface.py
+++ b/spectrumdevice/devices/spectrum_interface.py
@@ -245,7 +245,7 @@ class SpectrumDeviceInterface(ABC):
 
     @property
     @abstractmethod
-    def feature_list(self) -> Tuple[List[CardFeature], List[AdvancedCardFeature]]:
+    def feature_list(self) -> List[Tuple[List[CardFeature], List[AdvancedCardFeature]]]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/spectrumdevice/devices/spectrum_star_hub.py
+++ b/spectrumdevice/devices/spectrum_star_hub.py
@@ -406,11 +406,11 @@ class SpectrumStarHub(SpectrumDevice):
     @property
     def feature_list(self) -> List[Tuple[List[CardFeature], List[AdvancedCardFeature]]]:
         """Get a list of the features of the child cards. See CardFeature, AdvancedCardFeature and the Spectrum
-        documentation for more information. The features should be the same across all child cards. If not, an
-        exception is raised.
+        documentation for more information.
 
         Returns:
-            features (Tuple[List[CardFeature], List[AdvancedCardFeature]]): A list of features and advanced features.
+            features (List[Tuple[List[CardFeature], List[AdvancedCardFeature]]]): A list of tuples, one per child card.
+                Each tuple contains a list of features and a list of advanced features for that card.
         """
         return [card.feature_list[0] for card in self._child_cards]
 

--- a/spectrumdevice/devices/spectrum_star_hub.py
+++ b/spectrumdevice/devices/spectrum_star_hub.py
@@ -21,7 +21,7 @@ from spectrumdevice.settings.io_lines import AvailableIOModes
 from spectrumdevice.settings.triggering import TriggerSource, ExternalTriggerMode
 from spectrumdevice.settings.card_features import CardFeature, AdvancedCardFeature
 from spectrumdevice.settings.transfer_buffer import TransferBuffer, CardToPCDataTransferBuffer
-from spectrum_gmbh.regs import SPC_SYNC_ENABLEMASK, SPC_PCIFEATURES
+from spectrum_gmbh.regs import SPC_SYNC_ENABLEMASK
 
 
 class SpectrumStarHub(SpectrumDevice):

--- a/spectrumdevice/devices/spectrum_star_hub.py
+++ b/spectrumdevice/devices/spectrum_star_hub.py
@@ -404,7 +404,7 @@ class SpectrumStarHub(SpectrumDevice):
             d.set_timeout_in_ms(timeout_ms)
 
     @property
-    def feature_list(self) -> Tuple[List[CardFeature], List[AdvancedCardFeature]]:
+    def feature_list(self) -> List[Tuple[List[CardFeature], List[AdvancedCardFeature]]]:
         """Get a list of the features of the child cards. See CardFeature, AdvancedCardFeature and the Spectrum
         documentation for more information. The features should be the same across all child cards. If not, an
         exception is raised.
@@ -412,11 +412,7 @@ class SpectrumStarHub(SpectrumDevice):
         Returns:
             features (Tuple[List[CardFeature], List[AdvancedCardFeature]]): A list of features and advanced features.
         """
-        feature_list_codes = []
-        for card in self._child_cards:
-            feature_list_codes.append(card.read_spectrum_device_register(SPC_PCIFEATURES))
-        _check_settings_constant_across_devices(feature_list_codes, __name__)
-        return self._child_cards[0].feature_list
+        return [card.feature_list[0] for card in self._child_cards]
 
     @property
     def available_io_modes(self) -> AvailableIOModes:

--- a/spectrumdevice/settings/triggering.py
+++ b/spectrumdevice/settings/triggering.py
@@ -53,8 +53,12 @@ class TriggerSource(Enum):
     """No trigger source selected."""
 
 
-EXTERNAL_TRIGGER_SOURCES = [TriggerSource.SPC_TMASK_EXT0, TriggerSource.SPC_TMASK_EXT1, TriggerSource.SPC_TMASK_EXT2,
-                            TriggerSource.SPC_TMASK_EXT3]
+EXTERNAL_TRIGGER_SOURCES = [
+    TriggerSource.SPC_TMASK_EXT0,
+    TriggerSource.SPC_TMASK_EXT1,
+    TriggerSource.SPC_TMASK_EXT2,
+    TriggerSource.SPC_TMASK_EXT3,
+]
 
 
 class ExternalTriggerMode(Enum):

--- a/spectrumdevice/settings/triggering.py
+++ b/spectrumdevice/settings/triggering.py
@@ -53,6 +53,10 @@ class TriggerSource(Enum):
     """No trigger source selected."""
 
 
+EXTERNAL_TRIGGER_SOURCES = [TriggerSource.SPC_TMASK_EXT0, TriggerSource.SPC_TMASK_EXT1, TriggerSource.SPC_TMASK_EXT2,
+                            TriggerSource.SPC_TMASK_EXT3]
+
+
 class ExternalTriggerMode(Enum):
     """An Enum representing the supported trigger modes. See the Spectrum documentation more more Information.
 

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -12,24 +12,24 @@ class SpectrumTestMode(Enum):
 
 # Set to TestMode.MOCK_HARDWARE for software-only testing, even if Spectrum drivers are found on the system
 # Set to TestMode.REAL_HARDWARE to run tests on a real hardware device as configured below.
-SINGLE_CARD_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
+SINGLE_CARD_TEST_MODE = SpectrumTestMode.REAL_HARDWARE
 STAR_HUB_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
 
 # Set IP address of real spectrum device (for use if TestMode.REAL_HARDWARE is set above). Set to None to run tests on
 # a local (PCIe) card.
-TEST_DEVICE_IP = "169.254.142.75"
+TEST_DEVICE_IP = None
 # Set the device number to connect to for real hardware tests. If using a star hub (e.g. netbox), this should be the
 # STAR_HUB_MASTER_CARD_INDEX. If you only have a single, local (PCIe) card, set to 0.
-TEST_DEVICE_NUMBER = 1
+TEST_DEVICE_NUMBER = 0
 
 # Configure the card. These values are used to set up Mock devices as well as to check the configuration of real
 # hardware devices, so should match your real hardware if SpectrumTestMode.REAL_HARDWARE is being used.
-NUM_MODULES_PER_CARD = 2
-NUM_CHANNELS_PER_MODULE = 4
+NUM_MODULES_PER_CARD = 1
+NUM_CHANNELS_PER_MODULE = 2
 NUM_CARDS_IN_STAR_HUB = 2
 STAR_HUB_MASTER_CARD_INDEX = 1
 
-# Number of samples to acquire per channel during testing (on both mock and real devices)
+# Number of samples to acquire per channel during unit testing (on both mock and real devices)
 ACQUISITION_LENGTH = 4096
 
 # Rate at which mock frames (sets of waveforms) will be generated in SpectrumTestMode.MOCK_HARDWARE

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -12,8 +12,8 @@ class SpectrumTestMode(Enum):
 
 # Set to TestMode.MOCK_HARDWARE for software-only testing, even if Spectrum drivers are found on the system
 # Set to TestMode.REAL_HARDWARE to run tests on a real hardware device as configured below.
-SINGLE_CARD_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
-STAR_HUB_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
+SINGLE_CARD_TEST_MODE = SpectrumTestMode.REAL_HARDWARE
+STAR_HUB_TEST_MODE = SpectrumTestMode.REAL_HARDWARE
 
 # Set IP address of real spectrum device (for use if TestMode.REAL_HARDWARE is set above). Set to None to run tests on
 # a local (PCIe) card.

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -12,8 +12,8 @@ class SpectrumTestMode(Enum):
 
 # Set to TestMode.MOCK_HARDWARE for software-only testing, even if Spectrum drivers are found on the system
 # Set to TestMode.REAL_HARDWARE to run tests on a real hardware device as configured below.
-SINGLE_CARD_TEST_MODE = SpectrumTestMode.REAL_HARDWARE
-STAR_HUB_TEST_MODE = SpectrumTestMode.REAL_HARDWARE
+SINGLE_CARD_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
+STAR_HUB_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
 
 # Set IP address of real spectrum device (for use if TestMode.REAL_HARDWARE is set above). Set to None to run tests on
 # a local (PCIe) card.

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+from spectrumdevice.settings import TriggerSource
 from spectrumdevice.spectrum_wrapper import SPECTRUM_DRIVERS_FOUND
 from spectrumdevice.exceptions import SpectrumIOError
 
@@ -14,14 +15,25 @@ class SpectrumTestMode(Enum):
 SINGLE_CARD_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
 STAR_HUB_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
 
-# Set IP address of real spectrum device (for use if TestMode.REAL_HARDWARE is set above)
+# Set IP address of real spectrum device (for use if TestMode.REAL_HARDWARE is set above). Set to None to run tests on
+# a local (PCIe) card.
 TEST_DEVICE_IP = "169.254.142.75"
+
+# Configure the card. These values are used to set up Mock devices as well as to check the configuration of real
+# hardware devices, so should match your real hardware if SpectrumTestMode.REAL_HARDWARE is being used.
 NUM_MODULES_PER_CARD = 2
 NUM_CHANNELS_PER_MODULE = 4
 NUM_CARDS_IN_STAR_HUB = 2
 STAR_HUB_MASTER_CARD_INDEX = 1
+
+# Number of samples to acquire per channel during testing (on both mock and real devices)
 ACQUISITION_LENGTH = 4096
-mock_device_test_frame_rate_hz = 10.0
+
+# Rate at which mock frames (sets of waveforms) will be generated in SpectrumTestMode.MOCK_HARDWARE
+MOCK_DEVICE_TEST_FRAME_RATE_HZ = 10.0
+
+# Trigger source to use for integration tests. Has no effect in SpectrumTestMode.MOCK_HARDWARE
+INTEGRATION_TEST_TRIGGER_SOURCE = TriggerSource.SPC_TMASK_SOFTWARE
 
 
 if SINGLE_CARD_TEST_MODE == SpectrumTestMode.REAL_HARDWARE and not SPECTRUM_DRIVERS_FOUND:

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -12,20 +12,20 @@ class SpectrumTestMode(Enum):
 
 # Set to TestMode.MOCK_HARDWARE for software-only testing, even if Spectrum drivers are found on the system
 # Set to TestMode.REAL_HARDWARE to run tests on a real hardware device as configured below.
-SINGLE_CARD_TEST_MODE = SpectrumTestMode.REAL_HARDWARE
+SINGLE_CARD_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
 STAR_HUB_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
 
 # Set IP address of real spectrum device (for use if TestMode.REAL_HARDWARE is set above). Set to None to run tests on
 # a local (PCIe) card.
-TEST_DEVICE_IP = None
+TEST_DEVICE_IP = "169.254.142.75"
 # Set the device number to connect to for real hardware tests. If using a star hub (e.g. netbox), this should be the
 # STAR_HUB_MASTER_CARD_INDEX. If you only have a single, local (PCIe) card, set to 0.
-TEST_DEVICE_NUMBER = 0
+TEST_DEVICE_NUMBER = 1
 
 # Configure the card. These values are used to set up Mock devices as well as to check the configuration of real
 # hardware devices, so should match your real hardware if SpectrumTestMode.REAL_HARDWARE is being used.
-NUM_MODULES_PER_CARD = 1
-NUM_CHANNELS_PER_MODULE = 2
+NUM_MODULES_PER_CARD = 2
+NUM_CHANNELS_PER_MODULE = 4
 NUM_CARDS_IN_STAR_HUB = 2
 STAR_HUB_MASTER_CARD_INDEX = 1
 

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -18,6 +18,9 @@ STAR_HUB_TEST_MODE = SpectrumTestMode.MOCK_HARDWARE
 # Set IP address of real spectrum device (for use if TestMode.REAL_HARDWARE is set above). Set to None to run tests on
 # a local (PCIe) card.
 TEST_DEVICE_IP = "169.254.142.75"
+# Set the device number to connect to for real hardware tests. If using a star hub (e.g. netbox), this should be the
+# STAR_HUB_MASTER_CARD_INDEX. If you only have a single, local (PCIe) card, set to 0.
+TEST_DEVICE_NUMBER = 1
 
 # Configure the card. These values are used to set up Mock devices as well as to check the configuration of real
 # hardware devices, so should match your real hardware if SpectrumTestMode.REAL_HARDWARE is being used.

--- a/tests/device_factories.py
+++ b/tests/device_factories.py
@@ -3,7 +3,7 @@ from spectrumdevice.devices.spectrum_card import SpectrumCard
 from spectrumdevice.devices.spectrum_star_hub import SpectrumStarHub
 from tests.configuration import (
     TEST_DEVICE_IP,
-    mock_device_test_frame_rate_hz,
+    MOCK_DEVICE_TEST_FRAME_RATE_HZ,
     NUM_MODULES_PER_CARD,
     NUM_CHANNELS_PER_MODULE,
     NUM_CARDS_IN_STAR_HUB,
@@ -22,13 +22,13 @@ def create_spectrum_card_for_testing() -> SpectrumCard:
     else:
         return MockSpectrumCard(
             device_number=0,
-            mock_source_frame_rate_hz=mock_device_test_frame_rate_hz,
+            mock_source_frame_rate_hz=MOCK_DEVICE_TEST_FRAME_RATE_HZ,
             num_modules=NUM_MODULES_PER_CARD,
             num_channels_per_module=NUM_CHANNELS_PER_MODULE,
         )
 
 
-def create_spectrum_start_hub_for_testing() -> SpectrumStarHub:
+def create_spectrum_star_hub_for_testing() -> SpectrumStarHub:
     """Configure a real or mock device for unit testing using the glabal constant values defined in
     tests/configuration.py"""
     if STAR_HUB_TEST_MODE == SpectrumTestMode.REAL_HARDWARE:
@@ -42,7 +42,7 @@ def create_spectrum_start_hub_for_testing() -> SpectrumStarHub:
             mock_child_cards.append(
                 MockSpectrumCard(
                     device_number=0,
-                    mock_source_frame_rate_hz=mock_device_test_frame_rate_hz,
+                    mock_source_frame_rate_hz=MOCK_DEVICE_TEST_FRAME_RATE_HZ,
                     num_modules=NUM_MODULES_PER_CARD,
                     num_channels_per_module=NUM_CHANNELS_PER_MODULE,
                 )

--- a/tests/device_factories.py
+++ b/tests/device_factories.py
@@ -10,7 +10,7 @@ from tests.configuration import (
     STAR_HUB_MASTER_CARD_INDEX,
     SpectrumTestMode,
     SINGLE_CARD_TEST_MODE,
-    STAR_HUB_TEST_MODE,
+    STAR_HUB_TEST_MODE, TEST_DEVICE_NUMBER,
 )
 
 
@@ -18,10 +18,10 @@ def create_spectrum_card_for_testing() -> SpectrumCard:
     """Configure a real or mock device for unit testing using the glabal constant values defined in
     tests/configuration.py"""
     if SINGLE_CARD_TEST_MODE == SpectrumTestMode.REAL_HARDWARE:
-        return SpectrumCard(device_number=1, ip_address=TEST_DEVICE_IP)
+        return SpectrumCard(device_number=TEST_DEVICE_NUMBER, ip_address=TEST_DEVICE_IP)
     else:
         return MockSpectrumCard(
-            device_number=0,
+            device_number=TEST_DEVICE_NUMBER,
             mock_source_frame_rate_hz=MOCK_DEVICE_TEST_FRAME_RATE_HZ,
             num_modules=NUM_MODULES_PER_CARD,
             num_channels_per_module=NUM_CHANNELS_PER_MODULE,

--- a/tests/device_factories.py
+++ b/tests/device_factories.py
@@ -10,7 +10,8 @@ from tests.configuration import (
     STAR_HUB_MASTER_CARD_INDEX,
     SpectrumTestMode,
     SINGLE_CARD_TEST_MODE,
-    STAR_HUB_TEST_MODE, TEST_DEVICE_NUMBER,
+    STAR_HUB_TEST_MODE,
+    TEST_DEVICE_NUMBER,
 )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,18 +16,17 @@ from tests.configuration import INTEGRATION_TEST_TRIGGER_SOURCE, NUM_CARDS_IN_ST
 
 
 @pytest.mark.integration
-class IntegrationTests(TestCase):
+class SingleCardIntegrationTests(TestCase):
     def setUp(self) -> None:
         self._single_card_mock_mode = SINGLE_CARD_TEST_MODE == SpectrumTestMode.MOCK_HARDWARE
-        self._star_hub_mock_mode = STAR_HUB_TEST_MODE == SpectrumTestMode.MOCK_HARDWARE
 
     def test_standard_single_mode(self) -> None:
         waveforms = standard_single_mode_example(mock_mode=self._single_card_mock_mode,
                                                  trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
                                                  device_number=TEST_DEVICE_NUMBER,
                                                  ip_address=TEST_DEVICE_IP)
-        self.assertEqual(len(waveforms), 4)
-        self.assertEqual([wfm.shape for wfm in waveforms], [(400,), (400,), (400,), (400,)])
+        self.assertEqual(len(waveforms), 1)
+        self.assertEqual([wfm.shape for wfm in waveforms], [(400,)])
 
     def test_finite_multi_fifo_mode(self) -> None:
         measurements = finite_multi_fifo_example(mock_mode=self._single_card_mock_mode, num_measurements=2,
@@ -45,9 +44,16 @@ class IntegrationTests(TestCase):
         self._asserts_for_fifo_mode(measurements)
 
     def _asserts_for_fifo_mode(self, measurements: List[List[ndarray]]) -> None:
-        self.assertTrue((array([len(measurement) for measurement in measurements]) == 4).all())
+        self.assertTrue((array([len(measurement) for measurement in measurements]) == 1).all())
         self.assertTrue((array([[wfm.shape for wfm in waveforms]
                                 for waveforms in measurements]).flatten() == 400).all())
+
+
+@pytest.mark.integration
+@pytest.mark.star_hub
+class StarHubIntegrationTests(TestCase):
+    def setUp(self) -> None:
+        self._star_hub_mock_mode = STAR_HUB_TEST_MODE == SpectrumTestMode.MOCK_HARDWARE
 
     def test_star_hub(self) -> None:
         hub = star_hub_example(mock_mode=self._star_hub_mock_mode, num_cards=NUM_CARDS_IN_STAR_HUB,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,7 +12,7 @@ from spectrumdevice.exceptions import SpectrumDriversNotFound
 from tests.configuration import INTEGRATION_TEST_TRIGGER_SOURCE, NUM_CARDS_IN_STAR_HUB, NUM_CHANNELS_PER_MODULE, \
     NUM_MODULES_PER_CARD, SINGLE_CARD_TEST_MODE, \
     STAR_HUB_MASTER_CARD_INDEX, STAR_HUB_TEST_MODE, \
-    SpectrumTestMode, TEST_DEVICE_IP
+    SpectrumTestMode, TEST_DEVICE_IP, TEST_DEVICE_NUMBER
 
 
 @pytest.mark.integration
@@ -24,7 +24,7 @@ class IntegrationTests(TestCase):
     def test_standard_single_mode(self) -> None:
         waveforms = standard_single_mode_example(mock_mode=self._single_card_mock_mode,
                                                  trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
-                                                 device_number=STAR_HUB_MASTER_CARD_INDEX,
+                                                 device_number=TEST_DEVICE_NUMBER,
                                                  ip_address=TEST_DEVICE_IP)
         self.assertEqual(len(waveforms), 4)
         self.assertEqual([wfm.shape for wfm in waveforms], [(400,), (400,), (400,), (400,)])
@@ -32,7 +32,7 @@ class IntegrationTests(TestCase):
     def test_finite_multi_fifo_mode(self) -> None:
         measurements = finite_multi_fifo_example(mock_mode=self._single_card_mock_mode, num_measurements=2,
                                                  trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
-                                                 device_number=STAR_HUB_MASTER_CARD_INDEX,
+                                                 device_number=TEST_DEVICE_NUMBER,
                                                  ip_address=TEST_DEVICE_IP)
         self._asserts_for_fifo_mode(measurements)
 
@@ -40,7 +40,7 @@ class IntegrationTests(TestCase):
         measurements = continuous_multi_fifo_example(mock_mode=self._single_card_mock_mode,
                                                      acquisition_duration_in_seconds=1.0,
                                                      trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
-                                                     device_number=STAR_HUB_MASTER_CARD_INDEX,
+                                                     device_number=TEST_DEVICE_NUMBER,
                                                      ip_address=TEST_DEVICE_IP)
         self._asserts_for_fifo_mode(measurements)
 
@@ -61,4 +61,5 @@ class IntegrationTests(TestCase):
 class NoDriversTest(TestCase):
     def test_fails_with_no_driver_without_mock_mode(self) -> None:
         with self.assertRaises(SpectrumDriversNotFound):
-            standard_single_mode_example(mock_mode=False, trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE)
+            standard_single_mode_example(mock_mode=False, trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
+                                         device_number=TEST_DEVICE_NUMBER)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,7 +2,7 @@ from typing import List
 from unittest import TestCase
 
 import pytest
-from numpy import ndarray
+from numpy import array, ndarray
 
 from example_scripts.connect_to_star_hub import star_hub_example  # type: ignore
 from example_scripts.continuous_multi_fifo_mode import continuous_multi_fifo_example  # type: ignore
@@ -12,7 +12,7 @@ from spectrumdevice.exceptions import SpectrumDriversNotFound
 from tests.configuration import INTEGRATION_TEST_TRIGGER_SOURCE, NUM_CARDS_IN_STAR_HUB, NUM_CHANNELS_PER_MODULE, \
     NUM_MODULES_PER_CARD, SINGLE_CARD_TEST_MODE, \
     STAR_HUB_MASTER_CARD_INDEX, STAR_HUB_TEST_MODE, \
-    SpectrumTestMode
+    SpectrumTestMode, TEST_DEVICE_IP
 
 
 @pytest.mark.integration
@@ -23,28 +23,31 @@ class IntegrationTests(TestCase):
 
     def test_standard_single_mode(self) -> None:
         waveforms = standard_single_mode_example(mock_mode=self._single_card_mock_mode,
-                                                 trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE)
+                                                 trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
+                                                 device_number=STAR_HUB_MASTER_CARD_INDEX,
+                                                 ip_address=TEST_DEVICE_IP)
         self.assertEqual(len(waveforms), 4)
         self.assertEqual([wfm.shape for wfm in waveforms], [(400,), (400,), (400,), (400,)])
 
     def test_finite_multi_fifo_mode(self) -> None:
         measurements = finite_multi_fifo_example(mock_mode=self._single_card_mock_mode, num_measurements=2,
-                                                 trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE)
+                                                 trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
+                                                 device_number=STAR_HUB_MASTER_CARD_INDEX,
+                                                 ip_address=TEST_DEVICE_IP)
         self._asserts_for_fifo_mode(measurements)
 
     def test_continuous_multi_fifo_mode(self) -> None:
         measurements = continuous_multi_fifo_example(mock_mode=self._single_card_mock_mode,
                                                      acquisition_duration_in_seconds=1.0,
-                                                     trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE)
+                                                     trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
+                                                     device_number=STAR_HUB_MASTER_CARD_INDEX,
+                                                     ip_address=TEST_DEVICE_IP)
         self._asserts_for_fifo_mode(measurements)
 
     def _asserts_for_fifo_mode(self, measurements: List[List[ndarray]]) -> None:
-        self.assertEqual(len(measurements), 2)
-        self.assertEqual([len(measurement) for measurement in measurements], [4, 4])
-        self.assertEqual(
-            [[wfm.shape for wfm in waveforms] for waveforms in measurements],
-            [[(400,), (400,), (400,), (400,)], [(400,), (400,), (400,), (400,)]],
-        )
+        self.assertTrue((array([len(measurement) for measurement in measurements]) == 4).all())
+        self.assertTrue((array([[wfm.shape for wfm in waveforms]
+                                for waveforms in measurements]).flatten() == 400).all())
 
     def test_star_hub(self) -> None:
         hub = star_hub_example(mock_mode=self._star_hub_mock_mode, num_cards=NUM_CARDS_IN_STAR_HUB,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,10 +9,18 @@ from example_scripts.continuous_multi_fifo_mode import continuous_multi_fifo_exa
 from example_scripts.finite_multi_fifo_mode import finite_multi_fifo_example  # type: ignore
 from example_scripts.standard_single_mode import standard_single_mode_example  # type: ignore
 from spectrumdevice.exceptions import SpectrumDriversNotFound
-from tests.configuration import INTEGRATION_TEST_TRIGGER_SOURCE, NUM_CARDS_IN_STAR_HUB, NUM_CHANNELS_PER_MODULE, \
-    NUM_MODULES_PER_CARD, SINGLE_CARD_TEST_MODE, \
-    STAR_HUB_MASTER_CARD_INDEX, STAR_HUB_TEST_MODE, \
-    SpectrumTestMode, TEST_DEVICE_IP, TEST_DEVICE_NUMBER
+from tests.configuration import (
+    INTEGRATION_TEST_TRIGGER_SOURCE,
+    NUM_CARDS_IN_STAR_HUB,
+    NUM_CHANNELS_PER_MODULE,
+    NUM_MODULES_PER_CARD,
+    SINGLE_CARD_TEST_MODE,
+    STAR_HUB_MASTER_CARD_INDEX,
+    STAR_HUB_TEST_MODE,
+    SpectrumTestMode,
+    TEST_DEVICE_IP,
+    TEST_DEVICE_NUMBER,
+)
 
 
 @pytest.mark.integration
@@ -21,32 +29,40 @@ class SingleCardIntegrationTests(TestCase):
         self._single_card_mock_mode = SINGLE_CARD_TEST_MODE == SpectrumTestMode.MOCK_HARDWARE
 
     def test_standard_single_mode(self) -> None:
-        waveforms = standard_single_mode_example(mock_mode=self._single_card_mock_mode,
-                                                 trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
-                                                 device_number=TEST_DEVICE_NUMBER,
-                                                 ip_address=TEST_DEVICE_IP)
+        waveforms = standard_single_mode_example(
+            mock_mode=self._single_card_mock_mode,
+            trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
+            device_number=TEST_DEVICE_NUMBER,
+            ip_address=TEST_DEVICE_IP,
+        )
         self.assertEqual(len(waveforms), 1)
         self.assertEqual([wfm.shape for wfm in waveforms], [(400,)])
 
     def test_finite_multi_fifo_mode(self) -> None:
-        measurements = finite_multi_fifo_example(mock_mode=self._single_card_mock_mode, num_measurements=2,
-                                                 trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
-                                                 device_number=TEST_DEVICE_NUMBER,
-                                                 ip_address=TEST_DEVICE_IP)
+        measurements = finite_multi_fifo_example(
+            mock_mode=self._single_card_mock_mode,
+            num_measurements=2,
+            trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
+            device_number=TEST_DEVICE_NUMBER,
+            ip_address=TEST_DEVICE_IP,
+        )
         self._asserts_for_fifo_mode(measurements)
 
     def test_continuous_multi_fifo_mode(self) -> None:
-        measurements = continuous_multi_fifo_example(mock_mode=self._single_card_mock_mode,
-                                                     acquisition_duration_in_seconds=1.0,
-                                                     trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
-                                                     device_number=TEST_DEVICE_NUMBER,
-                                                     ip_address=TEST_DEVICE_IP)
+        measurements = continuous_multi_fifo_example(
+            mock_mode=self._single_card_mock_mode,
+            acquisition_duration_in_seconds=1.0,
+            trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
+            device_number=TEST_DEVICE_NUMBER,
+            ip_address=TEST_DEVICE_IP,
+        )
         self._asserts_for_fifo_mode(measurements)
 
     def _asserts_for_fifo_mode(self, measurements: List[List[ndarray]]) -> None:
         self.assertTrue((array([len(measurement) for measurement in measurements]) == 1).all())
-        self.assertTrue((array([[wfm.shape for wfm in waveforms]
-                                for waveforms in measurements]).flatten() == 400).all())
+        self.assertTrue(
+            (array([[wfm.shape for wfm in waveforms] for waveforms in measurements]).flatten() == 400).all()
+        )
 
 
 @pytest.mark.integration
@@ -56,8 +72,11 @@ class StarHubIntegrationTests(TestCase):
         self._star_hub_mock_mode = STAR_HUB_TEST_MODE == SpectrumTestMode.MOCK_HARDWARE
 
     def test_star_hub(self) -> None:
-        hub = star_hub_example(mock_mode=self._star_hub_mock_mode, num_cards=NUM_CARDS_IN_STAR_HUB,
-                               master_card_index=STAR_HUB_MASTER_CARD_INDEX)
+        hub = star_hub_example(
+            mock_mode=self._star_hub_mock_mode,
+            num_cards=NUM_CARDS_IN_STAR_HUB,
+            master_card_index=STAR_HUB_MASTER_CARD_INDEX,
+        )
         self.assertEqual(len(hub.channels), NUM_CHANNELS_PER_MODULE * NUM_MODULES_PER_CARD * NUM_CARDS_IN_STAR_HUB)
         self.assertEqual(len(hub._child_cards), NUM_CARDS_IN_STAR_HUB)
 
@@ -67,5 +86,6 @@ class StarHubIntegrationTests(TestCase):
 class NoDriversTest(TestCase):
     def test_fails_with_no_driver_without_mock_mode(self) -> None:
         with self.assertRaises(SpectrumDriversNotFound):
-            standard_single_mode_example(mock_mode=False, trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE,
-                                         device_number=TEST_DEVICE_NUMBER)
+            standard_single_mode_example(
+                mock_mode=False, trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE, device_number=TEST_DEVICE_NUMBER
+            )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,21 +9,25 @@ from example_scripts.continuous_multi_fifo_mode import continuous_multi_fifo_exa
 from example_scripts.finite_multi_fifo_mode import finite_multi_fifo_example  # type: ignore
 from example_scripts.standard_single_mode import standard_single_mode_example  # type: ignore
 from spectrumdevice.exceptions import SpectrumDriversNotFound
+from spectrumdevice.settings import TriggerSource
+from tests.configuration import INTEGRATION_TEST_TRIGGER_SOURCE
 
 
 @pytest.mark.integration
 class StandardSingleModeTest(TestCase):
     def test_standard_single_mode(self) -> None:
-        waveforms = standard_single_mode_example(mock_mode=True)
+        waveforms = standard_single_mode_example(mock_mode=True, trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE)
         self.assertEqual(len(waveforms), 4)
         self.assertEqual([wfm.shape for wfm in waveforms], [(400,), (400,), (400,), (400,)])
 
     def test_finite_multi_fifo_mode(self) -> None:
-        measurements = finite_multi_fifo_example(mock_mode=True, num_measurements=2)
+        measurements = finite_multi_fifo_example(mock_mode=True, num_measurements=2,
+                                                 trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE)
         self._asserts_for_fifo_mode(measurements)
 
     def test_continuous_multi_fifo_mode(self) -> None:
-        measurements = continuous_multi_fifo_example(mock_mode=True, acquisition_duration_in_seconds=1.0)
+        measurements = continuous_multi_fifo_example(mock_mode=True, acquisition_duration_in_seconds=1.0,
+                                                     trigger_source=INTEGRATION_TEST_TRIGGER_SOURCE)
         self._asserts_for_fifo_mode(measurements)
 
     def _asserts_for_fifo_mode(self, measurements: List[List[ndarray]]) -> None:

--- a/tests/test_single_card.py
+++ b/tests/test_single_card.py
@@ -116,9 +116,11 @@ class SingleCardTest(TestCase):
 
     def test_features(self) -> None:
         try:
-            _, _ = self._device.feature_list
+            feature_list = self._device.feature_list
         except Exception as e:
             self.assertTrue(False, f"raised an exception {e}")
+            feature_list = []
+        self.assertEqual(len(feature_list), 1)
 
     def test_available_io_modes(self) -> None:
         try:

--- a/tests/test_single_card.py
+++ b/tests/test_single_card.py
@@ -1,7 +1,5 @@
 from unittest import TestCase
 
-import pytest
-
 from spectrumdevice.devices.spectrum_channel import SpectrumChannel
 from spectrumdevice.devices.spectrum_device import SpectrumDevice
 from spectrumdevice.settings.device_modes import AcquisitionMode, ClockMode

--- a/tests/test_single_card.py
+++ b/tests/test_single_card.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+import pytest
+
 from spectrumdevice.devices.spectrum_channel import SpectrumChannel
 from spectrumdevice.devices.spectrum_device import SpectrumDevice
 from spectrumdevice.settings.device_modes import AcquisitionMode, ClockMode

--- a/tests/test_star_hub.py
+++ b/tests/test_star_hub.py
@@ -64,3 +64,11 @@ class StarHubTest(SingleCardTest):
         buffer = [CardToPCDataTransferBuffer(ACQUISITION_LENGTH) for _ in range(NUM_CARDS_IN_STAR_HUB)]
         self._device.define_transfer_buffer(buffer)
         self.assertTrue((array(self._device.transfer_buffers) == buffer).all())
+
+    def test_features(self) -> None:
+        try:
+            feature_list = self._device.feature_list
+        except Exception as e:
+            self.assertTrue(False, f"raised an exception {e}")
+            feature_list = []
+        self.assertEqual(len(feature_list), NUM_CARDS_IN_STAR_HUB)

--- a/tests/test_star_hub.py
+++ b/tests/test_star_hub.py
@@ -5,7 +5,7 @@ from spectrumdevice.devices.spectrum_star_hub import SpectrumStarHub
 from spectrumdevice.settings.channel import SpectrumChannelName
 from spectrumdevice.settings.transfer_buffer import CardToPCDataTransferBuffer
 from spectrumdevice.exceptions import SpectrumInvalidNumberOfEnabledChannels
-from tests.device_factories import create_spectrum_start_hub_for_testing
+from tests.device_factories import create_spectrum_star_hub_for_testing
 from tests.test_single_card import SingleCardTest
 from tests.configuration import (
     NUM_CHANNELS_PER_MODULE,
@@ -18,7 +18,7 @@ from spectrum_gmbh.regs import SPC_CHENABLE
 
 class StarHubTest(SingleCardTest):
     def setUp(self) -> None:
-        self._device: SpectrumStarHub = create_spectrum_start_hub_for_testing()
+        self._device: SpectrumStarHub = create_spectrum_star_hub_for_testing()
 
         self._expected_num_channels_each_card = NUM_CHANNELS_PER_MODULE * NUM_MODULES_PER_CARD
         self._expected_total_num_channels = self._expected_num_channels_each_card * NUM_CARDS_IN_STAR_HUB

--- a/tests/test_star_hub.py
+++ b/tests/test_star_hub.py
@@ -1,3 +1,4 @@
+import pytest
 from numpy import array
 
 from spectrumdevice.devices.spectrum_channel import SpectrumChannel
@@ -16,6 +17,7 @@ from tests.configuration import (
 from spectrum_gmbh.regs import SPC_CHENABLE
 
 
+@pytest.mark.star_hub
 class StarHubTest(SingleCardTest):
     def setUp(self) -> None:
         self._device: SpectrumStarHub = create_spectrum_star_hub_for_testing()


### PR DESCRIPTION
Fixes #6.

The tests described in #6 were carried out. During the testing, the following bugs were encountered and fixed:

- `SpectrumDevice.configure_trigger()` will now only apply external trigger settings if an external trigger is enabled.
- `SpectrumDevice.list_features` now returns a feature tuple for each card of a device, as the features in each card may differ.

Several improvements were also made to the test package to aid with testing on hardware.