### PR TITLE
Bug fix in get_waveforms()

### DIFF
--- a/spectrumdevice/devices/spectrum_card.py
+++ b/spectrumdevice/devices/spectrum_card.py
@@ -224,10 +224,13 @@ class SpectrumCard(SpectrumDevice):
         if self.acquisition_mode == AcquisitionMode.SPC_REC_FIFO_MULTI:
             self.wait_for_transfer_to_complete()
             num_available_bytes = self.read_spectrum_device_register(SPC_DATA_AVAIL_USER_LEN)
-            self.write_to_spectrum_device_register(SPC_DATA_AVAIL_CARD_LEN, num_available_bytes)
+        else:
+            num_available_bytes = 0
         waveforms_in_columns = copy(self.transfer_buffers[0].data_array).reshape(
             (self.acquisition_length_in_samples, len(self.enabled_channels))
         )
+        if self.acquisition_mode == AcquisitionMode.SPC_REC_FIFO_MULTI:
+            self.write_to_spectrum_device_register(SPC_DATA_AVAIL_CARD_LEN, num_available_bytes)
         return [waveform for waveform in waveforms_in_columns.T]
 
     def disconnect(self) -> None:

--- a/tests/test_star_hub.py
+++ b/tests/test_star_hub.py
@@ -26,7 +26,7 @@ class StarHubTest(SingleCardTest):
         self._expected_total_num_channels = self._expected_num_channels_each_card * NUM_CARDS_IN_STAR_HUB
 
         self._all_spectrum_channel_identifiers = [c.value for c in SpectrumChannelName]
-        self._all_spectrum_channel_identifiers.sort()  # Enums are unordered so ensure channels are in ascending order
+        self._all_spectrum_channel_identifiers.sort()  # Enums are unordered to ensure channels are in ascending order
 
     def tearDown(self) -> None:
         self._device.disconnect()


### PR DESCRIPTION
Changed SpectrumCard.get_waveforms() to wait until after data has been copied to mark bytes of buffer as free.

Fixed #8 