### PR TITLE
Python 3.12

### DIFF
--- a/.github/workflows/spectrumdevice-integration-tests.yml
+++ b/.github/workflows/spectrumdevice-integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/spectrumdevice-integration-tests.yml
+++ b/.github/workflows/spectrumdevice-integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/spectrumdevice-linters.yml
+++ b/.github/workflows/spectrumdevice-linters.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
 
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/spectrumdevice-unit-tests.yml
+++ b/.github/workflows/spectrumdevice-unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/spectrumdevice-unit-tests.yml
+++ b/.github/workflows/spectrumdevice-unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Limitations section for more information.
 * [PyPI](https://pypi.org/project/spectrumdevice/)
 
 ## Requirements
+Python 3.9+
+
 `spectrumdevice` works with hardware on Windows and Linux. Spectrum do not currently provide a hardware driver for 
 macOS, but `spectrumdevice` provides mock classes for development and testing without hardware, which work on macOS.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,12 +49,12 @@ test=pytest
 
 [options.extras_require]
 test =
- pytest == 6.2.5
+ pytest == 7.4.3
 dev =
- flake8 == 4.0
- flake8-bugbear == 21.9.2
+ flake8 == 6.1.0
+ flake8-bugbear == 23.9.16
  black == 22.3.0
- mypy == 1.3.0
+ mypy == 1.6.1
  types-setuptools == 67.8.0.0
 doc =
  pdoc == 8.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
  Operating System :: POSIX :: Linux
  Operating System :: Microsoft :: Windows :: Windows 10
  Operating System :: MacOS :: MacOS X
- Programming Language :: Python :: 3.8
  Programming Language :: Python :: 3.9
  Programming Language :: Python :: 3.10
  Programming Language :: Python :: 3.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,8 @@ classifiers =
  Programming Language :: Python :: 3.8
  Programming Language :: Python :: 3.9
  Programming Language :: Python :: 3.10
-  Programming Language :: Python :: 3.11
+ Programming Language :: Python :: 3.11
+ Programming Language :: Python :: 3.12
  Topic :: Scientific/Engineering
  Typing :: Typed
 project_urls =
@@ -61,7 +62,7 @@ examples =
  matplotlib >= 3.5.0
 
 [mypy]
-python_version = 3.11
+python_version = 3.12
 warn_unused_configs = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True

--- a/src/spectrumdevice/spectrum_wrapper/error_handler.py
+++ b/src/spectrumdevice/spectrum_wrapper/error_handler.py
@@ -1,14 +1,12 @@
 """Defines an error handling wrapper function for wrapping calls to the Spectrum API."""
-
 # Christian Baker, King's College London
 # Copyright (c) 2021 School of Biomedical Engineering & Imaging Sciences, King's College London
 # Licensed under the MIT. You may obtain a copy at https://opensource.org/licenses/MIT.
 
 import logging
 from functools import wraps
+from importlib import resources
 from typing import Callable, Dict, Any
-
-from pkg_resources import resource_filename
 
 from spectrumdevice.exceptions import SpectrumApiCallFailed, SpectrumFIFOModeHardwareBufferOverrun
 from spectrum_gmbh.spcerr import (
@@ -24,10 +22,12 @@ logger = logging.getLogger(__name__)
 
 def _parse_errors_table() -> Dict[int, str]:
     errors: Dict[int, str] = {}
-    with open(resource_filename(__name__, "spectrum_errors.csv"), "r") as f:
-        for line in f.readlines():
-            cells = line.split(",")
-            errors[int(cells[2].strip())] = cells[3].strip()
+    errors_file = resources.files(__name__) / 'spectrum_errors.csv'
+    with resources.as_file(errors_file) as file_path:
+        with open(file_path) as f:
+            for line in f.readlines():
+                cells = line.split(",")
+                errors[int(cells[2].strip())] = cells[3].strip()
     return errors
 
 

--- a/src/spectrumdevice/spectrum_wrapper/error_handler.py
+++ b/src/spectrumdevice/spectrum_wrapper/error_handler.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 def _parse_errors_table() -> Dict[int, str]:
     errors: Dict[int, str] = {}
-    errors_file = resources.files(__name__) / 'spectrum_errors.csv'
+    errors_file = resources.files(__package__) / "spectrum_errors.csv"
     with resources.as_file(errors_file) as file_path:
         with open(file_path) as f:
             for line in f.readlines():


### PR DESCRIPTION
Works on 3.12.

Removed support fro 3.8 so I can use `importlib.resources` for loading the `spectrum_errors.csv` instead of now deprecated `pkg_resources.resource_filename`... a little bit early as officially 3.8 is still supported until next year.